### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 images/
+.DS_Store


### PR DESCRIPTION
## Summary

- Ajout de `.DS_Store` au `.gitignore` pour éviter que les fichiers macOS apparaissent dans les changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)