### PR TITLE
fix: corriger le titre "Journée" en "Janvier" dans le village

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -3149,6 +3149,6 @@
     "imageFile": "463.jpg",
     "isPrivate": false,
     "text": "Le calendrier affiche la fin de l’hiver ! Un poulain vient de naître. Dans les « flourennes » noisetiers et saules sont fiers d’afficher leurs premiers chatons. Mais, hélas, l’hiver est toujours bien là ! Le sol gelé dans la nuit, prolonge son sommeil. Les greniers vidés de leur foin. L’auto-suffisance ne saura pas contenir la soudure printemps – hiver Ce matin, dès le lever du soleil, le village sera mobilisé au service du troupeau. Les derniers choux, betteraves et pommes de terre ne suffiront pas. Dans l’après-midi, il faudra retrouver la lande et prélever de l’ajonc. Grimper sur les chênes pour les dépouiller de leur lierre. Couper du houx pour ses maigres feuilles. Si ces efforts ne suffisent pas, alors il faudra peut-être réduire le troupeau.",
-    "title": "Journée dans le village"
+    "title": "Janvier dans le village"
   }
 ]


### PR DESCRIPTION
## Summary
- Correction du titre de la dernière entrée dans `data/data.json` : `"Journée dans le village"` → `"Janvier dans le village"`

## Test plan
- [ ] Vérifier que le titre s'affiche correctement dans l'application

🤖 Generated with [Claude Code](https://claude.com/claude-code)